### PR TITLE
Correction d'un bug sur la détection des commentaires

### DIFF
--- a/audit-conformite-rgaa/moulinette/src/AuditDataAnalyser.php
+++ b/audit-conformite-rgaa/moulinette/src/AuditDataAnalyser.php
@@ -79,7 +79,8 @@ class AuditDataAnalyser extends AbstractAuditDataAnalyser {
         }
 
         // Récupération des commentaires.
-        if (NULL == $value = $cells->get('I' . $row)->getValue()) {
+        $current_cell = $cells->get('I' . $row);
+        if (!$current_cell || NULL == $value = $current_cell->getValue()) {
           continue;
         }
 

--- a/audit-conformite-rgaa/moulinette/src/AuditFlashDataAnalyser.php
+++ b/audit-conformite-rgaa/moulinette/src/AuditFlashDataAnalyser.php
@@ -91,7 +91,8 @@ class AuditFlashDataAnalyser extends AbstractAuditDataAnalyser {
         }
 
         // Récupération des commentaires.
-        if (NULL == $value = $cells->get('G' . $row)->getValue()) {
+        $current_cell = $cells->get('G' . $row);
+        if (!$current_cell || NULL == $value = $current_cell->getValue()) {
           continue;
         }
 


### PR DESCRIPTION
Sur certains relevés d'audits (rencontré sur une feuille créée sur excel mac), une case sans commentaire n'est pas toujours considérée comme une case vide mais comme non-existante.

Un test a été ajouté pour vérifier que la case existe avant d'en vérifier la valeur.