### PR TITLE
Fix supression des sauts de ligne simples

### DIFF
--- a/audit-conformite-rgaa/moulinette/src/AbstractAuditDataAnalyser.php
+++ b/audit-conformite-rgaa/moulinette/src/AbstractAuditDataAnalyser.php
@@ -219,7 +219,6 @@ class AbstractAuditDataAnalyser {
       $sub_texts = preg_split("/\n\n/", $txt);
       $l = count($sub_texts);
       foreach ($sub_texts as $n => $sub_text) {
-        $sub_text = str_replace("\n", "", $sub_text);
         if ($n < $l - 1){
           $sub_text .= "\n\n";
         }


### PR DESCRIPTION
Lorsqu'un double saut de ligne est détecté dans un commentaire, la moulinette crée automatiquement deux anomalies.  Une erreur s'était glissée dans le code supprimant tous les sauts de ligne pour chaque anomalie.  Les anomalies étaient alors difficilement lisibles...